### PR TITLE
Allow customizing the unique identifier's prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ const DEFAULTS = {
   // {string} Property name of the component's unique identifier. Change this if 'vm.uid' conflicts
   // with another plugin or your own props.
   uidProperty: 'uid',
+  // {string} Prefix to use when generating unique identifiers. Change this to make your ids more
+  // unique on a page that already uses or could use a similar naming scheme.
+  uidPrefix: 'uid-',
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ const DEFAULTS = {
   // {string} Property name of the component's unique identifier. Change this if 'vm.uid' conflicts
   // with another plugin or your own props.
   uidProperty: 'uid',
-  // {string} Prefix to use when generating unique identifiers. Change this to make your ids more
-  // unique on a page that already uses or could use a similar naming scheme.
+
+  // {string} Prefix to use when generating HTML ids. Change this to make your ids more unique on a
+  // page that already uses or could use a similar naming scheme.
   uidPrefix: 'uid-',
 };
 ```

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,8 +29,9 @@ const DEFAULTS = {
   // {string} Property name of the component's unique identifier. Change this if 'vm.uid' conflicts
   // with another plugin or your own props.
   uidProperty: 'uid',
-  // {string} Prefix to use when generating unique identifiers. Change this to make your ids more
-  // unique on a page that already uses or could use a similar naming scheme.
+
+  // {string} Prefix to use when generating HTML ids. Change this to make your ids more unique on a
+  // page that already uses or could use a similar naming scheme.
   uidPrefix: 'uid-',
 };
 
@@ -44,7 +45,7 @@ export default function install(Vue, options = {}) {
   Vue.mixin({
     beforeCreate() {
       uidCounter += 1;
-      const uid = `${uidPrefix}${uidCounter}`;
+      const uid = uidPrefix + uidCounter;
       Object.defineProperties(this, {
         [uidProperty]: { get() { return uid; } },
       });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,18 +29,22 @@ const DEFAULTS = {
   // {string} Property name of the component's unique identifier. Change this if 'vm.uid' conflicts
   // with another plugin or your own props.
   uidProperty: 'uid',
+  // {string} Prefix to use when generating unique identifiers. Change this to make your ids more
+  // unique on a page that already uses or could use a similar naming scheme.
+  uidPrefix: 'uid-',
 };
 
 export default function install(Vue, options = {}) {
   // Don't use object spread to merge the defaults because bublé transforms that to Object.assign
   const uidProperty = options.uidProperty || DEFAULTS.uidProperty;
+  const uidPrefix = options.uidPrefix || DEFAULTS.uidPrefix;
 
   // Assign a unique id to each component
   let uidCounter = 0;
   Vue.mixin({
     beforeCreate() {
       uidCounter += 1;
-      const uid = `uid-${uidCounter}`;
+      const uid = `${uidPrefix}${uidCounter}`;
       Object.defineProperties(this, {
         [uidProperty]: { get() { return uid; } },
       });

--- a/test/test.js
+++ b/test/test.js
@@ -93,7 +93,7 @@ describe('Plugin', () => {
 
     it('uidPrefix', () => {
       const vm = new Vue();
-      assert.include(vm.$id(), 'custom-prefix-');
+      assert.isOk(vm.$id().startsWith(options.uidPrefix));
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -78,6 +78,7 @@ describe('Plugin', () => {
   describe('Options', () => {
     const options = {
       uidProperty: 'my_uid',
+      uidPrefix: 'custom-prefix-',
     };
     const Vue = createLocalVue();
     Vue.use(plugin, options);
@@ -88,6 +89,11 @@ describe('Plugin', () => {
       assert.isOk(uid);
       assert.isString(uid);
       assert.include(vm.$id(), uid);
+    });
+
+    it('uidPrefix', () => {
+      const vm = new Vue();
+      assert.include(vm.$id(), 'custom-prefix-');
     });
   });
 });

--- a/types/test/vue.ts
+++ b/types/test/vue.ts
@@ -4,6 +4,7 @@ import install from '../';
 install(Vue);
 install(Vue, {
   uidProperty: 'uid',
+  uidPrefix: 'uid-',
 });
 
 const vm = new Vue({});

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -38,4 +38,10 @@ export interface PluginOptions {
    * with another plugin or your own props.
    */
   uidProperty: string;
+
+  /**
+   * Prefix to use when generating HTML ids. Change this to make your ids more unique on a
+   * page that already uses or could use a similar naming scheme.
+   */
+  uidPrefix: string;
 }


### PR DESCRIPTION
I am building widgets to be consumed in external pages. Since I don't know what other markup or apps are running on those pages, I wanted to make sure the prefix was more unique to my code than just `uid-`.

Cheers!